### PR TITLE
Fix conversion error in Python3.7 for file name concatenation.

### DIFF
--- a/scripts/downloader.py
+++ b/scripts/downloader.py
@@ -13,6 +13,7 @@ OUTPUT_DIR = '/path/to/out/folder'
 
 def url_response(url):
     name, url = url
+    name = str(name)
     if not os.path.isfile(os.path.join(OUTPUT_DIR, name + ".pdf")):
         try:
             r = requests.get(url, stream = True)


### PR DESCRIPTION
I noticed that the script was throwing an error since for some reason the file ids were interpreted as integers and not strings, which lead to a conversion problem. Explicitly casting the id as string solves the problem.